### PR TITLE
fix: screen overflow on footer and background grid

### DIFF
--- a/lib/components/Footer.tsx
+++ b/lib/components/Footer.tsx
@@ -1,22 +1,22 @@
 'use client'
-import {GithubIcon, LinkedinIcon} from 'lucide-react'
+import { GithubIcon, LinkedinIcon } from 'lucide-react'
 import Link from 'next/link'
-import {usePathname} from 'next/navigation'
-import {META} from '~/constants/metadata'
+import { usePathname } from 'next/navigation'
+import { META } from '~/constants/metadata'
 import BackgroundGrid from './BackgroundGrid'
 import Button from './Button'
 import Title from './Title'
 
 const pages = [
-	{title: 'About', href: '/about'},
-	{title: 'Lab', href: '/lab'},
-	{title: 'Blog', href: '/blog'},
-	{title: 'Contact', href: '/contact'},
-	{title: 'Partners', href: '/partners'},
-	{title: 'Projects', href: '/projects'},
-	{title: 'Newsletter', href: '/newsletter'},
-	{title: 'Brand', href: 'https://brand.rubriclabs.com'},
-	{title: 'Sitemap', href: '/sitemap.xml'}
+	{ title: 'About', href: '/about' },
+	{ title: 'Lab', href: '/lab' },
+	{ title: 'Blog', href: '/blog' },
+	{ title: 'Contact', href: '/contact' },
+	{ title: 'Partners', href: '/partners' },
+	{ title: 'Projects', href: '/projects' },
+	{ title: 'Newsletter', href: '/newsletter' },
+	{ title: 'Brand', href: 'https://brand.rubriclabs.com' },
+	{ title: 'Sitemap', href: '/sitemap.xml' }
 ]
 
 const socials = [
@@ -51,7 +51,7 @@ const Footer = () => {
 	if (pathname.startsWith('/studio')) return <></>
 
 	return (
-		<div className='fixed bottom-0 z-10 flex h-[80vh] w-screen flex-col-reverse items-center justify-between gap-10 overflow-hidden bg-black px-5 py-16 text-white sm:h-96 sm:flex-row sm:items-center sm:gap-0 sm:px-10 sm:py-20 dark:bg-white dark:text-black'>
+		<div className='fixed bottom-0 z-10 flex h-[80vh] w-full flex-col-reverse items-center justify-between gap-10 overflow-hidden bg-black px-5 py-16 text-white sm:h-96 sm:flex-row sm:items-center sm:gap-0 sm:px-10 sm:py-20 dark:bg-white dark:text-black'>
 			<BackgroundGrid className='pointer-events-none absolute bottom-0 left-0 z-20 h-screen w-full' />
 			<div className='flex flex-col items-center gap-5 sm:items-start'>
 				<Link

--- a/lib/components/landing/HowWeWork.tsx
+++ b/lib/components/landing/HowWeWork.tsx
@@ -1,23 +1,23 @@
 'use client'
 
-import {AnimatePresence, motion, useInView} from 'framer-motion'
-import {useRef} from 'react'
+import { AnimatePresence, motion, useInView } from 'framer-motion'
+import { useRef } from 'react'
 import BackgroundGrid from '../BackgroundGrid'
 import SectionLayout from './SectionLayout'
 
 export const GradientBackgroundGrid = () => {
 	return (
-		<div className='parent absolute left-0 top-0 h-[100%] w-screen'>
-			<span className='absolute left-0 top-0 z-50 flex h-[20%] w-screen bg-gradient-to-b from-white to-white/0 dark:from-black dark:to-black/0' />
-			<BackgroundGrid className='absolute left-0 top-0 z-0 h-[100%] w-screen dark:opacity-10' />
-			<span className='absolute bottom-0 left-0 z-50 flex h-[20%] w-screen bg-gradient-to-t from-neutral-100 to-white/0 dark:from-neutral-900 dark:to-black/0' />
+		<div className='parent absolute left-0 top-0 h-[100%] w-full'>
+			<span className='absolute left-0 top-0 z-50 flex h-[20%] w-full bg-gradient-to-b from-white to-white/0 dark:from-black dark:to-black/0' />
+			<BackgroundGrid className='absolute left-0 top-0 z-0 h-[100%] w-full dark:opacity-10' />
+			<span className='absolute bottom-0 left-0 z-50 flex h-[20%] w-full bg-gradient-to-t from-neutral-100 to-white/0 dark:from-neutral-900 dark:to-black/0' />
 		</div>
 	)
 }
 
 export default function HowWeWork() {
 	const ref = useRef(null)
-	const isInView = useInView(ref, {once: true, amount: 0.4})
+	const isInView = useInView(ref, { once: true, amount: 0.4 })
 	return (
 		<SectionLayout
 			id='how-we-work'
@@ -29,8 +29,8 @@ export default function HowWeWork() {
 					initial='hidden'
 					animate={isInView ? 'visible' : 'hidden'}
 					variants={{
-						hidden: {opacity: 0, y: 50},
-						visible: {opacity: 1, y: 0, transition: {duration: 0.6, ease: 'easeOut'}}
+						hidden: { opacity: 0, y: 50 },
+						visible: { opacity: 1, y: 0, transition: { duration: 0.6, ease: 'easeOut' } }
 					}}
 					className='flex max-w-3xl flex-col'>
 					<div className='flex flex-col gap-5'>


### PR DESCRIPTION
The website has a screen overflow on the right side, seen in this screenshot (macOS on Arc and on Safari):
![image](https://github.com/RubricLab/website/assets/66485719/b1f27cd1-5880-4477-b5a0-6e8abadf84a8)
It's only on the hero, none of the other pages. It was caused by the footer and the background gradient. Fixed it by swapping `w-screen` with `w-full` on some elements. Grid visibility and responsiveness are maintained.
![image](https://github.com/RubricLab/website/assets/66485719/5afc3365-4eba-40fc-9b0e-ec873ea8e10e)
Notice no horizontal scrollbar. 

I've also formatted the two files I edited, and it should build properly.